### PR TITLE
Feature/aws codepipeline cicd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,18 @@
 FROM wordpress:latest
 
-# Copy custom themes and plugins
-COPY wp-content/themes /var/www/html/wp-content/themes
-COPY wp-content/plugins /var/www/html/wp-content/plugins
+# Create directory for custom theme
+RUN mkdir -p /usr/src/coct-theme
 
-# Set correct permissions
-RUN chown -R www-data:www-data /var/www/html/wp-content
+# Copy custom theme files from the repository
+COPY html/wp-content/themes/coct-theme /usr/src/coct-theme/
 
+# Copy the themes installation script
+COPY install-themes.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-themes.sh
+
+# Set up entrypoint wrapper
+COPY docker-entrypoint-custom.sh /usr/local/bin/docker-entrypoint-custom.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint-custom.sh
+
+ENTRYPOINT ["docker-entrypoint-custom.sh"]
 CMD ["apache2-foreground"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,10 @@
+FROM wordpress:latest
+
+# Copy custom themes and plugins
+COPY wp-content/themes /var/www/html/wp-content/themes
+COPY wp-content/plugins /var/www/html/wp-content/plugins
+
+# Set correct permissions
+RUN chown -R www-data:www-data /var/www/html/wp-content
+
+CMD ["apache2-foreground"]

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,44 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      python: 3.11
+    commands:
+      - aws --version
+      - docker --version
+  
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin $AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG=${COMMIT_HASH:=latest}
+
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - docker build -t $REPOSITORY_URI:latest -t $REPOSITORY_URI:$IMAGE_TAG .
+
+  post_build:
+    commands:
+      - echo Pushing the Docker image...
+      - docker push $REPOSITORY_URI:latest
+      - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - echo '[{"name":"wordpress","imageUri":"'$REPOSITORY_URI:$IMAGE_TAG'"}]' > image_definitions.json
+      
+
+artifacts:
+  files:
+    - image_definitions.json
+  discard-paths: yes
+  secondary-artifacts:
+    imagedefinitions:
+      base-directory: $CODEBUILD_SRC_DIR
+      files: imagedefinitions.json
+      name: "imagedefinitions"
+
+cache:
+  paths:
+    - '/root/.pip-cache/**/*'

--- a/docker-entrypoint-custom.sh
+++ b/docker-entrypoint-custom.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Install custom themes from the source code in the container
+echo "Installing/updating custom themes from build..."
+
+/usr/local/bin/install-themes.sh coct-theme
+
+echo "All themes installed/updated successfully"
+
+# Wait for EFS to be fully available (optional but can help with race conditions)
+echo "Ensuring EFS mounts are ready..."
+ls -la /var/www/html/wp-content/themes/
+ls -la /var/www/html/wp-content/plugins/
+ls -la /var/www/html/wp-content/uploads/
+
+# Run the original entrypoint
+echo "Starting WordPress..."
+exec /usr/local/bin/docker-entrypoint.sh "$@"
+

--- a/install-themes.sh
+++ b/install-themes.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+THEME_NAME=$1
+THEMES_DIR="/var/www/html/wp-content/themes"
+CUSTOM_THEME_DIR="${THEMES_DIR}/${THEME_NAME}"
+
+# Install custom theme from the source code in the container
+if [ -d "/usr/src/${THEME_NAME}" ]; then
+    echo "Installing/updating custom theme ${THEME_NAME} from build..."
+    
+    # Always force update the custom theme
+    if [ -d "$CUSTOM_THEME_DIR" ]; then
+        echo "Removing existing custom theme..."
+        rm -rf "$CUSTOM_THEME_DIR"
+    fi
+    
+    # Copy the custom theme to the WordPress themes directory
+    mkdir -p "$CUSTOM_THEME_DIR"
+    cp -r "/usr/src/${THEME_NAME}/*" "$CUSTOM_THEME_DIR/"
+    
+    # Set proper permissions
+    chown -R www-data:www-data "$CUSTOM_THEME_DIR"
+    chmod -R 755 "$CUSTOM_THEME_DIR"
+    
+    echo "Custom theme installed/updated successfully"
+fi


### PR DESCRIPTION
# What's in this PR?

Changes to allow AWS codepipeline to automatically build and deploy the docker image

## Changes made
- Added an entrypoint script to the image that copies over coct-theme to EFS
- added a buildspec file that the pipeline will follow to build the image